### PR TITLE
Make it possible to disable plugin activation

### DIFF
--- a/src/tox_ansible/hooks.py
+++ b/src/tox_ansible/hooks.py
@@ -46,11 +46,12 @@ try:
         combo that is discovered therein."""
         tox = tox_helper.Tox(config)
         options = Options(tox)
-        ansible = Ansible(options=options, base=tox.toxinidir)
 
         # Only execute inside of a collection, otherwise we have nothing to do
-        if not ansible.is_ansible:
+        if options.disabled:
             return
+
+        ansible = Ansible(options=options, base=tox.toxinidir)
 
         # Create any test cases that are discovered in the directory structure and
         # expand them per any configured matrix axes in the config file

--- a/src/tox_ansible/options.py
+++ b/src/tox_ansible/options.py
@@ -22,6 +22,8 @@ INI_YAMLLINT_CONFIG = "yamllint_config"
 INI_MOLECULE_CONFIG_FILES = "molecule_config_files"
 INI_SCENARIO_FORMAT = "scenario_format"
 INI_SCENARIO_FORMAT_DEFAULT = "$path-$parent-$name"
+INI_DISABLED = "disabled"
+INI_DISABLED_DEFAULT = False
 
 
 # pylint: disable=too-many-instance-attributes
@@ -77,8 +79,16 @@ class Options(object):
         paths = self.reader.getlist(INI_IGNORE_PATHS, sep="\n")
         return paths
 
+    @property
+    def disabled(self):
+        return self.reader.getbool(INI_DISABLED, INI_DISABLED_DEFAULT)
+
     def _parse_opt(self, option, opt, env):
-        if isinstance(option, dict) and option[opt] is not None:
+        if (
+            isinstance(option, dict)
+            and opt in option.keys()
+            and option[opt] is not None
+        ):
             values = list(map(lambda a: a.split(","), option[opt]))
             values = list(chain.from_iterable(values))
             return values

--- a/tests/fixtures/expand_collection/tox.ini
+++ b/tests/fixtures/expand_collection/tox.ini
@@ -14,6 +14,7 @@ ignore_path =
     ignored
 ansible_lint_config = some/path.config
 yamllint = some/yamllint.config
+disabled = false
 
 [testenv]
 usedevelop = false

--- a/tests/fixtures/expand_collection_comma/tox.ini
+++ b/tests/fixtures/expand_collection_comma/tox.ini
@@ -11,6 +11,7 @@ ignore_path =
     ignored
 ansible_lint_config = some/path.config
 yamllint = some/yamllint.config
+disabled = false
 
 [testenv]
 usedevelop = false

--- a/tests/fixtures/expand_collection_newlines/tox.ini
+++ b/tests/fixtures/expand_collection_newlines/tox.ini
@@ -15,6 +15,7 @@ ignore_path =
     ignored
 ansible_lint_config = some/path.config
 yamllint = some/yamllint.config
+disabled = false
 
 [testenv]
 usedevelop = false

--- a/tests/fixtures/has_deps/tox.ini
+++ b/tests/fixtures/has_deps/tox.ini
@@ -2,6 +2,9 @@
 skipdist = true
 envlist = lint_all
 
+[ansible]
+disabled = false
+
 [testenv]
 usedevelop = false
 skip_install = true

--- a/tests/fixtures/not_collection/tox.ini
+++ b/tests/fixtures/not_collection/tox.ini
@@ -2,6 +2,9 @@
 skipdist = true
 envlist = py27, py3{5,6,7,8}, py{27,38}-tox{2,3}0, lint, coverage
 
+[ansible]
+disabled = false
+
 [testenv]
 usedevelop = true
 deps =

--- a/tests/fixtures/nothing/molecule/dont_find_me/molecule.yml
+++ b/tests/fixtures/nothing/molecule/dont_find_me/molecule.yml
@@ -1,0 +1,3 @@
+# Intentionally left blank
+# If tox-ansible tries to find and parse this
+# file, then it will die a horrible death

--- a/tests/fixtures/nothing/tox.ini
+++ b/tests/fixtures/nothing/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = manual
+
+[ansible]
+disabled = true

--- a/tests/fixtures/simplified/tox.ini
+++ b/tests/fixtures/simplified/tox.ini
@@ -8,3 +8,4 @@ skip_install = true
 
 [ansible]
 scenario_format = $parent-$nondefault_name
+disabled = false

--- a/tests/test_ansible.py
+++ b/tests/test_ansible.py
@@ -6,24 +6,23 @@ from tox_ansible.ansible import Ansible
 
 
 @pytest.mark.parametrize(
-    "folder,expected",
+    "folder",
     [
-        ("tests/fixtures/collection", True),
-        ("tests/fixtures/expand_collection", True),
-        ("tests/fixtures/expand_collection_newlines", True),
-        ("tests/fixtures/not_collection", True),
-        ("tests/fixtures/has_deps", True),
-        ("tests/fixtures/nothing", False),
+        ("tests/fixtures/collection"),
+        ("tests/fixtures/expand_collection"),
+        ("tests/fixtures/expand_collection_newlines"),
+        ("tests/fixtures/not_collection"),
+        ("tests/fixtures/has_deps"),
+        ("tests/fixtures/nothing"),
     ],
 )
-def test_with_scenarios(mocker, folder, expected):
+def test_with_scenarios(mocker, folder):
     ansible = Ansible(base=folder)
     ansible.options = mocker.Mock()
     ansible.options.ignore_paths = []
     ansible.options.molecule_config_files = []
     # ansible._scenarios = scenarios  # pylint: disable=protected-access
     assert ansible.directory == os.path.realpath(folder)
-    assert ansible.is_ansible == expected
 
 
 def test_with_full_path():

--- a/tests/test_everything.py
+++ b/tests/test_everything.py
@@ -69,6 +69,7 @@ EXPECTED = {
             "two",
         ]
     ),
+    "tests/fixtures/nothing": "manual",
 }
 EXPECTED["tests/fixtures/expand_collection_comma"] = EXPECTED[
     "tests/fixtures/expand_collection"
@@ -115,6 +116,7 @@ def run_tox(args, capture):
         ("tests/fixtures/expand_collection_comma"),
         ("tests/fixtures/expand_collection_newlines"),
         ("tests/fixtures/not_collection"),
+        ("tests/fixtures/nothing"),
         ("tests/fixtures/simplified"),
     ],
 )
@@ -150,6 +152,9 @@ def test_run_tox_with_args(target, value, capfd):
 
 def test_run_with_test_command(capfd):
     with cd("tests/fixtures/collection"):
-        shutil.rmtree(".tox")
+        try:
+            shutil.rmtree(".tox")
+        except FileNotFoundError:
+            pass
         cli = run_tox(["-e", "roles-simple-default"], capfd)
     assert "tox-ansible is the best" in cli

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,6 +1,10 @@
+from configparser import ConfigParser
+from pathlib import Path
+
 import pytest
 
 from tox_ansible.options import Options
+from tox_ansible.tox_helper import Tox
 
 
 @pytest.fixture
@@ -38,3 +42,24 @@ def test_options_expand_matrix(opts, mocker):
     opts.matrix = mocker.Mock()
     opts.expand_matrix([])
     opts.matrix.expand.assert_called_once_with([])
+
+
+@pytest.mark.parametrize(
+    "folder,expected",
+    [
+        (Path("tests/fixtures/collection"), False),
+        (Path("tests/fixtures/expand_collection"), False),
+        (Path("tests/fixtures/expand_collection_newlines"), False),
+        (Path("tests/fixtures/has_deps"), False),
+        (Path("tests/fixtures/not_collection"), False),
+        (Path("tests/fixtures/nothing"), True),
+    ],
+)
+def test_disabled(mocker, folder, expected):
+    c = ConfigParser()
+    c.read(folder / "tox.ini")
+    config = mocker.Mock()
+    config._cfg = c  # pylint: disable=protected-access
+    tox = Tox(config)
+    options = Options(tox)
+    assert options.disabled == expected


### PR DESCRIPTION
Add an option to enable running tox-ansible, so that it does not disturb executions of project that do not need for users that happened to install the plugin at system level.

Fixes #40
Fixes #76