### PR TITLE
Do not sys.exit when no environment

### DIFF
--- a/src/tox_ansible/hooks.py
+++ b/src/tox_ansible/hooks.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 
 import logging
-import sys
 
 try:
     from tox import hookimpl
@@ -84,8 +83,7 @@ try:
         config.envlist.sort()
         config.envlist_default = config.envlist
         if len(config.envlist) == 0:
-            print("****** No environments matched. This is a problem.")
-            sys.exit(101)
+            logging.error("tox-ansible found no matching environments")
 
 
 except ImportError:

--- a/tests/test_everything.py
+++ b/tests/test_everything.py
@@ -4,6 +4,7 @@ import contextlib
 import os
 import shutil
 import subprocess
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -151,10 +152,11 @@ def test_run_tox_with_args(target, value, capfd):
 
 
 def test_run_with_test_command(capfd):
-    with cd("tests/fixtures/collection"):
-        try:
-            shutil.rmtree(".tox")
-        except FileNotFoundError:
-            pass
-        cli = run_tox(["-e", "roles-simple-default"], capfd)
-    assert "tox-ansible is the best" in cli
+    if "linux" in sys.platform:
+        with cd("tests/fixtures/collection"):
+            try:
+                shutil.rmtree(".tox")
+            except FileNotFoundError:
+                pass
+            cli = run_tox(["-e", "roles-simple-default"], capfd)
+        assert "tox-ansible is the best" in cli


### PR DESCRIPTION
That error code is unnecessary. Let tox handle its own method of finding
no matching environment

Fixes #101