### PR TITLE
Add ansible_test_platform option to tox.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,15 @@ ansible-test
 This plugin saves you this trouble by allowing you the freedom to run
 these commands tranparently. For example you can run `tox -e sanity` which
 will install the collection, change current directory and execute
-`ansible-test sanity --python X.Y`. You can even add posargs that endup being
+`ansible-test sanity --python X.Y`. You can even add posargs that end up being
 passed to the executed command, like `tox -e sanity -- --help`.
 
-By default tox-ansible will also limit execution of ansible-test to the
-current python version used by tox.
+By default, tox-ansible will also limit execution of ansible-test to the
+current python version used by tox. In addition, tox-ansible will try to
+automatically determine the best environment to run these tests in
+(docker if present on the host, virtualenv, etc.).
+
+You can disable this auto-detection feature in the `tox.ini`, see below for details.
 
 ```shell
 $ tox -va
@@ -31,6 +35,7 @@ sanity       -> Auto-generated for: ansible-test sanity
 
 Only those enviroments that are detected will be listed. At least sanity will
 always be visible as it does not require adding new files.
+
 
 More details
 ------------
@@ -168,6 +173,23 @@ environments specified in the config file. To suppress it, specify at least one 
 in the envlist entry within tox.ini
 
 ### tox.ini examples
+The `ansible_test_platform` option controls the platform (docker, venv, python version) that ansible-test targets run in.
+By default, this is set to `auto` for automatic detection. You can also set this option
+to `docker` or `venv` explicitly, or disable the Python and platform auto-detection by setting
+this option to `posargs`:
+
+```ini
+[ansible]
+ansible_test_platform = posargs # Disable auto-detection
+```
+
+Note that if you do this, you will have to add your own platform parameters to ansible-test via posargs,
+as discussed above. For example, to use a separate container for the controller and target hosts,
+you can use the following command:
+
+`$ tox -e integration -- --controller docker:default --target docker:centos7`
+
+
 To add arguments to every molecule invocation, add the
 following segment to tox.ini. Each argument needs to be on a separate line, which allows
 spaces and other special characters to be used without needing shell-style escapes:

--- a/src/tox_ansible/ansible/__init__.py
+++ b/src/tox_ansible/ansible/__init__.py
@@ -129,11 +129,15 @@ class Ansible(object):
         # pylint: disable=fixme
         # TODO(ssbarnea): Detect and enable only those tests that do exist
         # to avoid confusing tox user.
-
-        if use_docker():
+        docker_present = use_docker()
+        platform = self.options.ansible_test_platform
+        if (platform == "auto" and docker_present) or platform == "docker":
             opts = ["--docker", "default"]
-        else:
+        elif platform in ("auto", "venv"):
             opts = ["--venv"]
+        else:
+            opts = []
+
         # We use --venv because otherwise we risk getting errors from the
         # system environment, especially as one of tests performed is
         # 'pip check'.
@@ -169,7 +173,10 @@ class Ansible(object):
                 value["args"] = copy.deepcopy(self.tox.posargs)
             else:
                 value["args"].extend(self.tox.posargs)
-            if "--python" not in self.tox.posargs:
+            if (
+                "--python" not in self.tox.posargs
+                and self.options.ansible_test_platform == "auto"
+            ):
                 value["args"].extend(
                     ["--python", f"{sys.version_info[0]}.{sys.version_info[1]}"]
                 )

--- a/src/tox_ansible/options.py
+++ b/src/tox_ansible/options.py
@@ -17,6 +17,7 @@ INI_PYTHON_VERSIONS = "python"
 INI_ANSIBLE_VERSIONS = "ansible"
 INI_ANSIBLE_TEST_PLATFORM = "ansible_test_platform"
 INI_ANSIBLE_TEST_PLATFORM_DEFAULT = "auto"
+INI_ANSIBLE_TEST_PLATFORM_CHOICES = ["auto", "posargs", "docker", "venv"]
 INI_MOLECULE_GLOBAL_OPTS = "molecule_opts"
 INI_IGNORE_PATHS = "ignore_path"
 INI_ANSIBLE_LINT_CONFIG = "ansible_lint_config"
@@ -55,6 +56,16 @@ class Options(object):
         self.ansible_test_platform = self.reader.getstring(
             INI_ANSIBLE_TEST_PLATFORM, INI_ANSIBLE_TEST_PLATFORM_DEFAULT
         )
+        if self.ansible_test_platform not in INI_ANSIBLE_TEST_PLATFORM_CHOICES:
+            raise ValueError(
+                "Invalid value for 'ansible_test_platform': %s. "
+                "Supported values are: %s"
+                % (
+                    self.ansible_test_platform,
+                    ", ".join(INI_ANSIBLE_TEST_PLATFORM_CHOICES),
+                )
+            )
+
         pythons = self.reader.getlist(INI_PYTHON_VERSIONS)
         pythons = _split_env(pythons)
         if pythons:

--- a/src/tox_ansible/options.py
+++ b/src/tox_ansible/options.py
@@ -15,6 +15,8 @@ DRIVER_ENV_NAME = "TOX_" + DRIVER_OPTION_NAME.upper()
 INI_SECTION = "ansible"
 INI_PYTHON_VERSIONS = "python"
 INI_ANSIBLE_VERSIONS = "ansible"
+INI_ANSIBLE_TEST_PLATFORM = "ansible_test_platform"
+INI_ANSIBLE_TEST_PLATFORM_DEFAULT = "auto"
 INI_MOLECULE_GLOBAL_OPTS = "molecule_opts"
 INI_IGNORE_PATHS = "ignore_path"
 INI_ANSIBLE_LINT_CONFIG = "ansible_lint_config"
@@ -50,6 +52,9 @@ class Options(object):
         ansible = _split_env(ansible)
         if ansible:
             self.matrix.add_axis(AnsibleAxis(ansible))
+        self.ansible_test_platform = self.reader.getstring(
+            INI_ANSIBLE_TEST_PLATFORM, INI_ANSIBLE_TEST_PLATFORM_DEFAULT
+        )
         pythons = self.reader.getlist(INI_PYTHON_VERSIONS)
         pythons = _split_env(pythons)
         if pythons:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -13,6 +13,7 @@ def opts(mocker):
     reader = mocker.Mock()
     c.get_reader.return_value = reader
     reader.getlist.return_value = ["2.10", "3.9"]
+    reader.getstring.return_value = "auto"
     opts = Options(c)
     return opts
 

--- a/tests/test_tox_molecule_case.py
+++ b/tests/test_tox_molecule_case.py
@@ -23,6 +23,7 @@ def opts(mocker):
     reader = mocker.Mock()
     config.get_reader.return_value = reader
     reader.getlist.return_value = ["2.10", "3.9"]
+    reader.getstring.return_value = "auto"
     return Options(config)
 
 


### PR DESCRIPTION
Fixes https://github.com/tox-dev/tox-ansible/issues/130

This patch adds a new parameter to the tox.ini configuration that allows users to choose whether tox-ansible should try to automatically detect an appropiate platform for ansible-test.

As suggested, I also added some assertion logic to ensure that the platform is always a valid choice.
I assume that you want this assertion in `options.py`, so that any mistakes can be caught quickly upon reading the config file.
Please let me know If that is not the case!