### PR TITLE
Include python 3.7

### DIFF
--- a/.config/requirements-test.txt
+++ b/.config/requirements-test.txt
@@ -1,6 +1,5 @@
 ansible-core
 coverage
-devpi_process
 pre-commit
 pytest
 pytest_mock

--- a/.config/requirements-test.txt
+++ b/.config/requirements-test.txt
@@ -1,6 +1,5 @@
 ansible-core
 coverage
-pre-commit
 pytest
 pytest_mock
 pytest-xdist

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -25,7 +25,7 @@ jobs:
         id: generate_matrix
         uses: coactions/dynamic-matrix@v1
         with:
-          min_python: "3.8"
+          min_python: "3.7"
           max_python: "3.11"
           default_python: "3.11" # used by jobs in other_names
           other_names: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["ansible", "collections", "tox"]
 license = { text = "MIT" }
 maintainers = [{ "name" = "Ansible by Red Hat", "email" = "info@ansible.com" }]
 authors = [{ "name" = "Bradley A. Thornton", "email" = "bthornto@redhat.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 classifiers = [
   'Development Status :: 2 - Pre-Alpha',
   'Intended Audience :: Developers',
@@ -26,6 +26,7 @@ classifiers = [
   'Programming Language :: Python',
   'Programming Language :: Python :: 3',
   'Programming Language :: Python :: 3 :: Only',
+  'Programming Language :: Python :: 3.7',
   'Programming Language :: Python :: 3.8',
   'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
@@ -92,7 +93,7 @@ select = ["ALL"]
 # PLR0915 = too many statments, fixme
 # RET504 = prefer less complex return statements
 ignore = ["ARG", "FBT", "TID", "C901", "PLR0915", "RET504"]
-target-version = "py38"
+target-version = "py37"
 
 [tool.ruff.isort]
 lines-after-imports = 2 # Ensures consistency for cases when there's variable vs function/class definitions after imports

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -36,7 +36,7 @@ ALLOWED_EXTERNALS = [
     "echo",
 ]
 ENV_LIST = """
-{integration, sanity, unit}-py3.8-{2.9, 2.12, 2.13}
+{integration, sanity, unit}-py3.{7,8}-{2.9, 2.12, 2.13}
 {integration, sanity, unit}-py3.9-{2.12, 2.13, 2.14, 2.15, milestone, devel}
 {integration, sanity, unit}-py3.10-{2.12, 2.13, 2.14, 2.15, milestone, devel}
 {integration, sanity, unit}-py3.11-{2.14, 2.15, milestone, devel}


### PR DESCRIPTION
as the pytest-ansible plugin now has support for python3.7, we can include it here

https://github.com/ansible-community/pytest-ansible/pull/128

in both the matrix and plugin itself

We can revisit this later this year https://devguide.python.org/versions/  althoughansible collections typically extend past the python interpretter

This will allow for testing ansible 2.9 with 3.7