### PR TITLE
Python 3.7 for ansible 2.9 only

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -36,7 +36,8 @@ ALLOWED_EXTERNALS = [
     "echo",
 ]
 ENV_LIST = """
-{integration, sanity, unit}-py3.{7,8}-{2.9, 2.12, 2.13}
+{integration, sanity, unit}-py3.7-2.9
+{integration, sanity, unit}-py3.8-{2.9, 2.12, 2.13}
 {integration, sanity, unit}-py3.9-{2.12, 2.13, 2.14, 2.15, milestone, devel}
 {integration, sanity, unit}-py3.10-{2.12, 2.13, 2.14, 2.15, milestone, devel}
 {integration, sanity, unit}-py3.11-{2.14, 2.15, milestone, devel}


### PR DESCRIPTION
Fix an issue introduced in #182.

Python 3.7 is not support with ansible core 2.12 and 2.13.

https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html

Limit python 3.7 to ansible 2.9 only.