### PR TITLE
Switch to ANSIBLE_COLLECTION_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Sample `json`
 
 `tox` will, by default, create a python virtual environment for a given environment. `tox-ansible` adds ansible collection specific build and test logic to tox. The collection is copied into the virtual environment created by tox, built, and installed into the virtual environment. The installation of the collection will include the collection's collection dependencies. `tox-ansible` will also install any python dependencies from a `test-requirements.txt` and `requirements.txt` file. The virtual environment's temporary directory is used, so the copy, build and install steps are performed with each test run ensuring the current collection code is used.
 
-`tox-ansible` also sets the `ANSIBLE_COLLECTIONS_PATHS` environment variable to point to the virtual environment's temporary directory. This ensures that the collection under test is used when running tests. The `pytest-ansible-units` pytest plugin injects the `ANSIBLE_COLLECTIONS_PATHS` environment variable into the collection loader so ansible-core can locate the collection.
+`tox-ansible` also sets the `ANSIBLE_COLLECTIONS_PATH` environment variable to point to the virtual environment's temporary directory. This ensures that the collection under test is used when running tests. The `pytest-ansible-units` pytest plugin injects the `ANSIBLE_COLLECTIONS_PATH` environment variable into the collection loader so ansible-core can locate the collection.
 
 `pytest` is ued to run both the `unit` and `integration tests`.
 `ansible-test sanity` is used to run the `sanity` tests.

--- a/docs/integration.ini
+++ b/docs/integration.ini
@@ -1,7 +1,7 @@
 [testenv:integration-py3.11-devel]
 type = VirtualEnvRunner
 set_env =
-  ANSIBLE_COLLECTIONS_PATHS=/home/bthornto/github/tox-ansible/docs/integration-py3.11-devel/tmp/collections/
+  ANSIBLE_COLLECTIONS_PATH=/home/bthornto/github/tox-ansible/docs/integration-py3.11-devel/tmp/collections/
   PIP_DISABLE_PIP_VERSION_CHECK=1
   PYTHONHASHSEED=3119075902
   PYTHONIOENCODING=utf-8

--- a/docs/sanity.ini
+++ b/docs/sanity.ini
@@ -1,7 +1,7 @@
 [testenv:sanity-py3.11-devel]
 type = VirtualEnvRunner
 set_env =
-  ANSIBLE_COLLECTIONS_PATHS=/home/bthornto/github/tox-ansible/docs/sanity-py3.11-devel/tmp/collections/
+  ANSIBLE_COLLECTIONS_PATH=/home/bthornto/github/tox-ansible/docs/sanity-py3.11-devel/tmp/collections/
   PIP_DISABLE_PIP_VERSION_CHECK=1
   PYTHONHASHSEED=3868722208
   PYTHONIOENCODING=utf-8

--- a/docs/unit.ini
+++ b/docs/unit.ini
@@ -1,7 +1,7 @@
 [testenv:unit-py3.11-devel]
 type = VirtualEnvRunner
 set_env =
-  ANSIBLE_COLLECTIONS_PATHS=/home/bthornto/github/tox-ansible/docs/unit-py3.11-devel/tmp/collections/
+  ANSIBLE_COLLECTIONS_PATH=/home/bthornto/github/tox-ansible/docs/unit-py3.11-devel/tmp/collections/
   PIP_DISABLE_PIP_VERSION_CHECK=1
   PYTHONHASHSEED=1318243417
   PYTHONIOENCODING=utf-8

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -536,5 +536,5 @@ def conf_setenv(env_conf: EnvConfigSet) -> str:
     """
     envtmpdir = env_conf["envtmpdir"]
     setenv = []
-    setenv.append(f"ANSIBLE_COLLECTIONS_PATHS={envtmpdir}/collections/")
+    setenv.append(f"ANSIBLE_COLLECTIONS_PATH={envtmpdir}/collections/")
     return "\n".join(setenv)


### PR DESCRIPTION
`ANSIBLE_COLLECTION_PATH` is favored over `ANSIBLE_COLLECTION_PATHS`

```
[DEPRECATION WARNING]: ANSIBLE_COLLECTIONS_PATHS option, does not fit var 
naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead. This 
feature will be removed from ansible-core in version 2.19. Deprecation warnings
 can be disabled by setting deprecation_warnings=False in ansible.cfg.
```
in ansible-core devel