### PR TITLE
Replace rsync command

### DIFF
--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -35,7 +35,6 @@ ALLOWED_EXTERNALS = [
     "cp",
     "git",
     "rm",
-    "rsync",
     "mkdir",
     "cd",
     "echo",
@@ -448,8 +447,8 @@ def conf_commands_pre(
         group = "echo ::group::Copy the collection to the galaxy build dir"
         commands.append(group)
     cd_tox_dir = f"cd {TOX_WORK_DIR}"
-    rsync_cmd = f'rsync -r --cvs-exclude --filter=":- .gitignore" . {galaxy_build_dir}'
-    full_cmd = f"bash -c '{cd_tox_dir} && {rsync_cmd}'"
+    copy_cmd = f"cp -r --parents $(git ls-files 2> /dev/null || ls) {galaxy_build_dir}"
+    full_cmd = f"bash -c '{cd_tox_dir} && {copy_cmd}'"
     commands.append(full_cmd)
     if in_action():
         commands.append(end_group)


### PR DESCRIPTION
Replace `rsync` command with `git ls-files` and `cp` to minimize external dependencies and to also work on minimalistic Python container images

Fixes: #192 