### PR TITLE
Avoid full dep install prior to tox run

### DIFF
--- a/.config/dictionary.txt
+++ b/.config/dictionary.txt
@@ -7,6 +7,8 @@ endgroup
 envtmpdir
 envtmpdir
 fileh
+fixturenames
+metafunc
 nocolor
 passenv
 setenv

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           python-version: ${{ matrix.entry.python }}
 
-      - name: Install deps
-        run: python -m pip install -r test-requirements.txt
+      - name: Install tox-ansible, includes tox
+        run: python -m pip install tox-ansible
 
       - name: Run tox test
         run: python -m tox --ansible -e ${{ matrix.entry.name }} --conf tox-ansible.ini

--- a/src/tox_ansible/plugin.py
+++ b/src/tox_ansible/plugin.py
@@ -535,6 +535,7 @@ def conf_setenv(env_conf: EnvConfigSet) -> str:
 
     ansible 2.9 did not support the ANSIBLE_COLLECTION_PATH environment variable
     ansible 2.16 has it marked for deprecation in 2.19
+    Set the XDG_CACHE_HOME to the environment directory to isolate it
 
     :param env_conf: The environment configuration.
     :return: The set environment variables.
@@ -544,6 +545,9 @@ def conf_setenv(env_conf: EnvConfigSet) -> str:
     else:
         envvar_name = "ANSIBLE_COLLECTIONS_PATH"
     envtmpdir = env_conf["envtmpdir"]
-    setenv = []
-    setenv.append(f"{envvar_name}={envtmpdir}/collections/")
+
+    setenv = [
+        f"{envvar_name}={envtmpdir}/collections/",
+        f"XDG_CACHE_HOME={env_conf['env_dir']}/.cache",
+    ]
     return "\n".join(setenv)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,21 @@
 """Global testing fixtures."""
 
+from __future__ import annotations
+
+import configparser
+import os
+import subprocess
+import sys
+
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+
+if TYPE_CHECKING:
+    from _pytest.python import Metafunc
 
 
 @pytest.fixture(scope="module")
@@ -27,3 +40,59 @@ def _tox_in_tox(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("TOX_ENV_NAME", raising=False)
     monkeypatch.delenv("TOX_WORK_DIR", raising=False)
     monkeypatch.delenv("TOX_ENV_DIR", raising=False)
+
+
+@dataclass
+class BasicEnvironment:
+    """An structure for an environment."""
+
+    name: str
+    config: dict[str, str]
+
+
+def pytest_generate_tests(metafunc: Metafunc) -> None:
+    """Parametrize the basic environments and there configurations.
+
+    :param metafunc: Metadata for the test
+    """
+    if "basic_environment" in metafunc.fixturenames:
+        cwd = Path(__file__).parent
+        basic_dir = cwd / "fixtures" / "integration" / "test_basic"
+        try:
+            cmd = (
+                f"{sys.executable} -m tox config --ansible "
+                f"--root {basic_dir} --conf tox-ansible.ini"
+            )
+            env = os.environ
+            env.pop("TOX_ENV_DIR", None)
+            env.pop("TOX_ENV_NAME", None)
+            env.pop("TOX_WORK_DIR", None)
+
+            proc = subprocess.run(
+                args=cmd,
+                capture_output=True,
+                check=True,
+                cwd=str(basic_dir),
+                env=env,
+                shell=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            print(exc.stdout)
+            print(exc.stderr)
+            pytest.fail(exc.stderr)
+
+        configs = configparser.ConfigParser()
+        configs.read_string(proc.stdout)
+
+        assert configs.sections()
+
+        environment_configs = [
+            BasicEnvironment(name=name, config=dict(configs[name])) for name in configs.sections()
+        ]
+
+        metafunc.parametrize(
+            "basic_environment",
+            environment_configs,
+            ids=configs.sections(),
+        )

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -1,10 +1,19 @@
 """Basic tests."""
+
+from __future__ import annotations
+
 import json
 import subprocess
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ..conftest import BasicEnvironment
 
 
 def test_ansible_environments(module_fixture_dir: Path) -> None:
@@ -60,3 +69,26 @@ def test_gh_matrix(
         assert isinstance(entry["factors"], list)
         assert isinstance(entry["name"], str)
         assert isinstance(entry["python"], str)
+
+
+def test_environment_config(
+    basic_environment: BasicEnvironment,
+) -> None:
+    """Test that the ansible environment configurations are generated.
+
+    Ensure the environment configurations are generated and look for information unlikely to change
+    as a basic smoke test.
+
+    :param basic_environment: A dict representing the environment configuration
+    """
+    assert "py3" in basic_environment.name
+
+    config = basic_environment.config
+
+    assert config["allowlist_externals"]
+    assert config["commands_pre"]
+    assert config["commands"]
+    assert config["pass_env"]
+
+    assert "https://github.com/ansible/ansible/archive" in config["deps"]
+    assert "XDG_CACHE_HOME" in config["set_env"]


### PR DESCRIPTION
For the base python interpreter, only tox and tox-ansible should be needed since the collection specific deps will be installed per environment by the plugin.

This should save some set-up time and the full dep list is not needed in the base.

